### PR TITLE
fix for issue:

### DIFF
--- a/tboplayer.py
+++ b/tboplayer.py
@@ -1536,7 +1536,7 @@ class TBOPlayer:
             coords_m = self.RE_COORDS.match(coords)
             if coords_m is None or int(coords_m.group(1))>screenres[0] or int(coords_m.group(2))>screenres[1]:
                 coords = "+200+200"
-            geometry = "%dx%d%s" % (width, height + self.vprogress_bar.winfo_height(), coords)
+            geometry = "%dx%d%s" % (width, height, coords)
             self.vprogress_bar_window.geometry(geometry)
         else:
             self.options.full_screen = 1

--- a/tboplayer.py
+++ b/tboplayer.py
@@ -2642,8 +2642,6 @@ class ExceptionCatcher:
             raise SystemExit, msg
         except Exception:
             log.logException()
-            log.critical("fatal error, quitting and raising exception.")
-            self.widget.quit()
             raise
 
 
@@ -2654,7 +2652,7 @@ class ExceptionCatcher:
 
 
 if __name__ == "__main__":
-    datestring=" 06 Jan 2017"
+    datestring=" 08 Jan 2017"
     tk.CallWrapper = ExceptionCatcher
     bplayer = TBOPlayer()
 

--- a/tboplayer.py
+++ b/tboplayer.py
@@ -1843,11 +1843,13 @@ class TBOPlayer:
         if self.play_state == self._OMX_CLOSED:
             self.select_and_play_pending = False
             self.play_track()
+            self.track_titles_display.bind("<Double-1>", self.select_and_play)
         elif not self.select_and_play_pending:
+            self.track_titles_display.unbind("<Double-1>")
             self.select_and_play_pending = True
             self.stop_track()
         if self.select_and_play_pending:
-            self.root.after(100, self.select_and_play)
+            self.root.after(200, self.select_and_play)
 
     	
     def select_next_track(self):


### PR DESCRIPTION
https://github.com/KenT2/tboplayer/issues/64

 heniotierra commented

@eysispeisi I don't think the player should exit upon catching errors related to DBUS connection, because the user should still be able to control omxplayer, except not using the DBUS interfaces' methods.