### PR TITLE
Exception, e: ERROR

### DIFF
--- a/tboplayer.py
+++ b/tboplayer.py
@@ -1075,7 +1075,7 @@ class TBOPlayer:
         }
         try:
             allowed_option_values = allowed_options_values[option]
-        except KeyError, er:
+        except KeyError:
             raise KeyError("Option " + option + " is invalid")
         option_type = str(type(allowed_option_values))
         if (allowed_option_values == "str" or 
@@ -1276,7 +1276,7 @@ class TBOPlayer:
         try:
             self.omx.set_video_geometry(0, 0, screenres[0], screenres[1])
             self.vprogress_grip.lower(self.vprogress_bar_frame)
-        except Exception, e:
+        except Exception as e:
             self.monitor('      [!] set_full_screen failed')
             self.monitor(e)
 
@@ -1329,7 +1329,7 @@ class TBOPlayer:
             y2 -= self.vprogress_bar.winfo_height()
         try:
             self.omx.set_video_geometry(x1, y1, x2, y2)
-        except Exception, e:
+        except Exception as e:
                 self.monitor('      [!] move_video failed')
                 self.monitor(e)
         self.focus_root()


### PR DESCRIPTION
Changed to Exception as e:
...and so.  #Botspot/pi-apps/issues/111

> @heniotierra same. I think that these **Exception, e:** should be **Exception as e:** instead, you know
> 
> ```
> 
> pi@basiliscus:~ $ python /opt/tboplayer/tboplayer.py
>   File "/opt/tboplayer/tboplayer.py", line 1279
>     except Exception e:
>                      ^
> SyntaxError: invalid syntax
> pi@basiliscus:~ $ python3 /opt/tboplayer/tboplayer.py
>   File "/opt/tboplayer/tboplayer.py", line 1078
>     except KeyError, er:
>                    ^
> SyntaxError: invalid syntax
> ```
BUT THERE IS STILL ANOTHER PROBLEM:
```
pi@basiliscus:~ $ python3 /opt/tboplayer/tboplayer.py
Traceback (most recent call last):
  File "/opt/tboplayer/tboplayer.py", line 59, in <module>
    from options import *
  File "/opt/tboplayer/options.py", line 3, in <module>
    import ConfigParser
ModuleNotFoundError: No module named 'ConfigParser'
pi@basiliscus:~ $ python /opt/tboplayer/tboplayer.py
Traceback (most recent call last):
  File "/opt/tboplayer/tboplayer.py", line 75, in <module>
    from youtubesearchpython import SearchVideos
  File "/home/pi/.local/lib/python2.7/site-packages/youtubesearchpython/__init__.py", line 1, in <module>
    from youtubesearchpython.videos__search import SearchVideos
  File "/home/pi/.local/lib/python2.7/site-packages/youtubesearchpython/videos__search.py", line 3, in <module>
    from youtubesearchpython.__requesthandler import RequestHandler
  File "/home/pi/.local/lib/python2.7/site-packages/youtubesearchpython/__requesthandler.py", line 4, in <module>
    from urllib import urlencode, urlopen, Request
ImportError: cannot import name Request

```

